### PR TITLE
Add autoload to command

### DIFF
--- a/key-assist.el
+++ b/key-assist.el
@@ -325,6 +325,7 @@ internally for processing 'collection lists."
 ;;
 ;;; Interactive functions:
 
+;;;###autoload
 (defun key-assist (&optional spec prompt nosort)
   "Prompt to eval a locally relevant function, with hints and keybindings.
 Press TAB to see the hints.


### PR DESCRIPTION
Use autoload technology to speed up the startup of Emacs.